### PR TITLE
Fix FileService issues with static

### DIFF
--- a/project4/gunrock_web/FileService.cpp
+++ b/project4/gunrock_web/FileService.cpp
@@ -12,16 +12,15 @@
 
 using namespace std;
 
-FileService::FileService() : HttpService("/") {
-  // while (endswith(basedir, "/")) {
-  //   basedir = basedir.substr(0, basedir.length() - 1);
-  // }
+FileService::FileService(std::string basedir) : HttpService("/") {
+  while (endswith(basedir, "/")) {
+    basedir = basedir.substr(0, basedir.length() - 1);
+  }
 
-  // if (basedir.length() == 0) {
-  //   cout << "invalid basedir" << endl;
-  //   exit(1);
-  // }
-  this->m_basedir = "static";
+  if (basedir.length() == 0) {
+    cout << "invalid basedir" << endl;
+    exit(1);
+  }
 }
 
 bool FileService::endswith(string str, string suffix) {

--- a/project4/gunrock_web/FileService.cpp
+++ b/project4/gunrock_web/FileService.cpp
@@ -12,17 +12,16 @@
 
 using namespace std;
 
-FileService::FileService(string basedir) : HttpService("/") {
-  while (endswith(basedir, "/")) {
-    basedir = basedir.substr(0, basedir.length() - 1);
-  }
+FileService::FileService() : HttpService("/") {
+  // while (endswith(basedir, "/")) {
+  //   basedir = basedir.substr(0, basedir.length() - 1);
+  // }
 
-  if (basedir.length() == 0) {
-    cout << "invalid basedir" << endl;
-    exit(1);
-  }
-  
-  this->m_basedir = basedir;
+  // if (basedir.length() == 0) {
+  //   cout << "invalid basedir" << endl;
+  //   exit(1);
+  // }
+  this->m_basedir = "static";
 }
 
 bool FileService::endswith(string str, string suffix) {

--- a/project4/gunrock_web/FileService.cpp
+++ b/project4/gunrock_web/FileService.cpp
@@ -21,6 +21,7 @@ FileService::FileService(std::string basedir) : HttpService("/") {
     cout << "invalid basedir" << endl;
     exit(1);
   }
+  this->m_basedir = basedir;
 }
 
 bool FileService::endswith(string str, string suffix) {

--- a/project4/gunrock_web/gunrock.cpp
+++ b/project4/gunrock_web/gunrock.cpp
@@ -167,7 +167,7 @@ int main(int argc, char *argv[]) {
   // The order that you push services dictates the search order
   // for path prefix matching
   services.push_back(new DistributedFileSystemService(DISKFILE));
-  services.push_back(new FileService(BASEDIR));
+  services.push_back(new FileService());
   
   while(true) {
     sync_print("waiting_to_accept", "");

--- a/project4/gunrock_web/gunrock.cpp
+++ b/project4/gunrock_web/gunrock.cpp
@@ -158,7 +158,7 @@ int main(int argc, char *argv[]) {
 
   set_log_file(LOGFILE);
 
-  cout << "Lisening on port " << PORT << endl;
+  cout << "Listening on port " << PORT << endl;
   
   sync_print("init", "");
   MyServerSocket *server = new MyServerSocket(PORT);

--- a/project4/gunrock_web/gunrock.cpp
+++ b/project4/gunrock_web/gunrock.cpp
@@ -167,7 +167,7 @@ int main(int argc, char *argv[]) {
   // The order that you push services dictates the search order
   // for path prefix matching
   services.push_back(new DistributedFileSystemService(DISKFILE));
-  services.push_back(new FileService("static"));
+  services.push_back(new FileService(BASEDIR));
   
   while(true) {
     sync_print("waiting_to_accept", "");

--- a/project4/gunrock_web/gunrock.cpp
+++ b/project4/gunrock_web/gunrock.cpp
@@ -26,7 +26,7 @@ using namespace std;
 int PORT = 8080;
 int THREAD_POOL_SIZE = 1;
 int BUFFER_SIZE = 1;
-string BASEDIR = "ds3";
+string BASEDIR = "static";
 string SCHEDALG = "FIFO";
 string LOGFILE = "/dev/null";
 string DISKFILE = "disk.img";
@@ -167,7 +167,7 @@ int main(int argc, char *argv[]) {
   // The order that you push services dictates the search order
   // for path prefix matching
   services.push_back(new DistributedFileSystemService(DISKFILE));
-  services.push_back(new FileService());
+  services.push_back(new FileService("static"));
   
   while(true) {
     sync_print("waiting_to_accept", "");

--- a/project4/gunrock_web/include/FileService.h
+++ b/project4/gunrock_web/include/FileService.h
@@ -7,7 +7,7 @@
 
 class FileService : public HttpService {
  public:
-  FileService(std::string basedir);
+  FileService();
 
   virtual void get(HTTPRequest *request, HTTPResponse *response);
   virtual void head(HTTPRequest *request, HTTPResponse *response);

--- a/project4/gunrock_web/include/FileService.h
+++ b/project4/gunrock_web/include/FileService.h
@@ -7,7 +7,7 @@
 
 class FileService : public HttpService {
  public:
-  FileService();
+  FileService(std::string basedir);
 
   virtual void get(HTTPRequest *request, HTTPResponse *response);
   virtual void head(HTTPRequest *request, HTTPResponse *response);


### PR DESCRIPTION
Project 4 had some issues with being able to see the static folder content on when you ran ./gunrock_web and pathed to them with a local host port. The issue seemed to be that the base directory that FileService was using was not correct, and instead it should had been using "static" as the base directory. Since FileService is only used for these cases, redesigned FileService constructor to always use "static" as the basedir.